### PR TITLE
supply chain use cases

### DIFF
--- a/UseCases/README.md
+++ b/UseCases/README.md
@@ -4,6 +4,7 @@ For our project the term "use cases" is used loosely and means any
 
 There are two subdirectories ("[Value Scenarios](./ValueScenarios/)", "[Practioner Playbooks](./PractionerPlaybooks/)"), aimed at two different audiences.
 There is a third subdirectory ("Fictitious Props") which support both of the previous directories.
+There is a fourth subdirectory("[]()")
 
 Value Scenarios describe the value proposition of the work of the TC.
 The intended audience of Value Scenarios is outside the TC,
@@ -27,3 +28,10 @@ provides a common reference across the OSIM documents and use cases,
 using a few fictitious entities.
 Any resemblance to actual persons/companies/organizations/tools/products
 is coincidental and unintended.
+
+To fully appreciate the value of the OSIM use cases 
+requires understanding of the broader supply chain uses
+in which OSIM plays a role.
+For example to see the value of information modeling to 
+software bill of materials (SBOM), 
+you first have to undershand the value of SBOMs.

--- a/UseCases/SupplyChain/README.md
+++ b/UseCases/SupplyChain/README.md
@@ -39,3 +39,26 @@ mergers and acquisition (M&A) decisions. For each use, the document provides a b
 narrative description followed by a table that summarizes the use cases’ actors, 
 business motivation, objectives, steps to achieve the objectives, SBOM elements used, 
 other supplementary data, and benefits achieved.
+
+The use cases are:
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+* link to be provided once use case agreed to 
+
+## References
+Much of the text in this document was based on previous work.
+This section provides the documents that were referenced above.
+### SBOM Operations Working Group
+1. SBOM Community, SBOM Operations Working Group. Improving Risk Management Decisions with SBOM Data. (2025, March 2). https://docs.google.com/document/d/1vFVbWEJmNsAbNPRAtHclC89YQlLUt6xYIvKmFGRkcQA/edit?tab=t.0#heading=h.10zm8vq6u9e0 {Editor's Note: Link will be replaced once doc published on CISA website}

--- a/UseCases/SupplyChain/README.md
+++ b/UseCases/SupplyChain/README.md
@@ -1,0 +1,41 @@
+# Broader Supply Chain Value Propositions and Use Cases
+To fully appreciate the value of the OSIM use cases 
+requires understanding of the broader supply chain uses
+in which OSIM plays a role.
+For example to see the value of information modeling to 
+software bill of materials (SBOM), 
+you first have to undershand the value of SBOMs.
+
+The use cases in this directory are broader than OSIM 
+and show the value of supply chain transparence in general.
+
+The purpose of these use cases is to demonstrate the benefits of 
+Software Bills of Materials (SBOMs) to software Producers and Consumers. 
+It strives to answer the questions: 
+“Once I generate or receive an SBOM, what do I do with it?” and 
+“What additional insights or intelligence can I gain from the SBOM 
+that will benefit my organization?”
+
+The document answers these questions in two major ways: 
+
+1. It defines the SBOM Lifecycle by explaining and depicting what happens to an SBOM from the point after its generation by the software Producer to its analysis and consumption by the Consumer. 
+2. It provides thirteen practical use cases that exemplify how the SBOM can be used by a variety of stakeholders to benefit their organizations.
+
+The SBOM Lifecycle depicts operations that occur through three major phases of an SBOM’s life: Production, Sharing, and Consumption. 
+It further categorizes these operations into three levels of maturity: 
+* Basic SBOM Operations cover the SBOM’s generation, verification, publishing, storage, and consumption. 
+* Advanced SBOM Operations describe how Producers or Consumers work with SBOMs to derive further value; for example, they can compare, enrich, or merge SBOMs and analyze SBOMs for a variety of risks. 
+* Continuous Vulnerability Management operations are the most mature, such as regular post-release monitoring of SBOMs for newly discovered risks.
+
+Thirteen use cases describe real situations in which Producers or Consumers 
+utilize SBOMs to extract information of value to their organizations. 
+These use cases span the SBOM’s Lifecycle and 
+cover topics such as how SBOMs can be used to: 
+pinpoint differences between software versions; 
+identify security, licensing or compliance risks; 
+alert organizations when software components are nearing their end of support; 
+inform incident responders of impacted software; and support procurement or 
+mergers and acquisition (M&A) decisions. For each use, the document provides a brief 
+narrative description followed by a table that summarizes the use cases’ actors, 
+business motivation, objectives, steps to achieve the objectives, SBOM elements used, 
+other supplementary data, and benefits achieved.


### PR DESCRIPTION
The is a framework PR to put a directory in the use case directory for uses cases that are broader than OSIM and set the stage to better understand OSIM value. Those use cases will be added in separate PRs. This is just a give a place to put them.